### PR TITLE
I don't think (x and y) in buffer is probably what you want here. Owing ...

### DIFF
--- a/tests/test_ircclient.py
+++ b/tests/test_ircclient.py
@@ -30,7 +30,7 @@ class IrcWrapperTestCase(unittest.TestCase):
         self.wrapper._register()
         nick = 'NICK test\r\n'
         user = 'USER test 3 * tester\r\n'
-        self.assertTrue((nick and user) in self.wrapper.out_buffer)
+        self.assertTrue(nick in self.wrapper.out_buffer and user in self.wrapper.out_buffer)
         self.assertEqual(nick, self.wrapper.out_buffer.split('\r\n')[0] + '\r\n')
         self.assertEqual(user, self.wrapper.out_buffer.split('\r\n')[1] + '\r\n')
     


### PR DESCRIPTION
...to the way Python short-circuits boolean expressions, (x and y) will eval to y before performing the in check, so in effect you're asserting that both names are not False (which will always be True, having just been assigned) and that y is present in the buffer. Just noticed this browsing your code -- hope it's helpful.
